### PR TITLE
Update passphrase-existing.html

### DIFF
--- a/css/freewallet-desktop.css
+++ b/css/freewallet-desktop.css
@@ -536,7 +536,7 @@ li.history-list-received .history-list-amount {
     display: block;
     position: relative;
 }
-.toggle-icon {
+#toggle-icon {
     position: absolute;
     bottom: 18px;
     right: 20px;

--- a/css/freewallet-desktop.css
+++ b/css/freewallet-desktop.css
@@ -536,7 +536,7 @@ li.history-list-received .history-list-amount {
     display: block;
     position: relative;
 }
-#toggle-icon {
+#showhide-icon {
     position: absolute;
     bottom: 18px;
     right: 20px;

--- a/css/freewallet-desktop.css
+++ b/css/freewallet-desktop.css
@@ -532,6 +532,15 @@ li.history-list-received .history-list-amount {
 .btc-wallet-address .modal-dialog {
     max-width: 350px;
 }
+#showhide {
+    display: block;
+    position: relative;
+}
+.toggle-icon {
+    position: absolute;
+    bottom: 18px;
+    right: 20px;
+}
 
 .normal-page-content {
     height: calc(100vh - 82px);

--- a/html/passphrase-existing.html
+++ b/html/passphrase-existing.html
@@ -67,15 +67,15 @@ $(document).ready(function(){
     });
 
     // Allow user to toggle passphrase display
-    $("#toggle-icon").click(function(){
+    $("#showhide-icon").click(function(){
         var addOrRemove = $("#manualPassphrase").hasClass('active');
 
         // set input type to text or password and toggle icon
         if(addOrRemove) {
-            $("#toggle-icon").removeClass('fa-eye').addClass('fa-eye-slash');
+            $("#showhide-icon").removeClass('fa-eye').addClass('fa-eye-slash');
             $("#manualPassphrase").attr("type", "text");
         } else {
-            $("#toggle-icon").removeClass('fa-eye-slash').addClass('fa-eye');
+            $("#showhide-icon").removeClass('fa-eye-slash').addClass('fa-eye');
             $('#manualPassphrase').attr("type", "password");
         }
         $('#manualPassphrase').toggleClass( 'active');

--- a/html/passphrase-existing.html
+++ b/html/passphrase-existing.html
@@ -1,10 +1,14 @@
 <div id="existing-passphrase" class="center">
     <p>Please enter your existing 12-word wallet passphrase and click 'Ok'</p>
-    <input type="password" class="btc-wallet-passphrase" id="manualPassphrase" autocomplete="off" >
-    <div id="showhide">
-        <i id="toggle-icon" class="fa fa-2x fa-inverse fa-eye-slash"></i>
+    <input type="text" class="btc-wallet-passphrase" id="manualPassphrase" autocomplete="off" >
+
+
+    <!--  new markup to show eye of sauron  -->
+    <div class="showhide">
+        <i id="toggleIcon" class="fa fa-2x fa-inverse fa-eye-slash" style="bottom:58px; right:20px; position:absolute;"></i>
     </div>
  
+
     <div class="input-group pull-left" style="width:180px" id="amount-value-wrapper">
         <label class="input-group-addon">Format</label>
         <select id="format-select" name="format" class="selectpicker">
@@ -66,17 +70,20 @@ $(document).ready(function(){
         }
     });
 
-    // Allow user to toggle display of passphrase
-    $("#toggle-icon).click(function(){
+    // Allow user to toggle passphrase display
+    $("#toggleIcon").click(function(){
         var addOrRemove = $("#manualPassphrase").hasClass('active');
+
+        // set input type to text or password and toggle icon
         if(addOrRemove) {
-            $("#toggle-icon").removeClass('fa-eye').addClass('fa-eye-slash');
+            $("#toggleIcon").removeClass('fa-eye').addClass('fa-eye-slash');
             $("#manualPassphrase").attr("type", "text");
         } else {
-            $("#toggle-icon").removeClass('fa-eye-slash').addClass('fa-eye');
+            $("#toggleIcon").removeClass('fa-eye-slash').addClass('fa-eye');
             $('#manualPassphrase').attr("type", "password");
         }
         $('#manualPassphrase').toggleClass( 'active');
+
     });
 
 });

--- a/html/passphrase-existing.html
+++ b/html/passphrase-existing.html
@@ -1,14 +1,10 @@
 <div id="existing-passphrase" class="center">
     <p>Please enter your existing 12-word wallet passphrase and click 'Ok'</p>
     <input type="text" class="btc-wallet-passphrase" id="manualPassphrase" autocomplete="off" >
-
-
-    <!--  new markup to show eye of sauron  -->
     <div class="showhide">
         <i id="toggle-icon" class="fa fa-2x fa-inverse fa-eye-slash" style="bottom:58px; right:20px; position:absolute;"></i>
     </div>
  
-
     <div class="input-group pull-left" style="width:180px" id="amount-value-wrapper">
         <label class="input-group-addon">Format</label>
         <select id="format-select" name="format" class="selectpicker">

--- a/html/passphrase-existing.html
+++ b/html/passphrase-existing.html
@@ -1,6 +1,9 @@
 <div id="existing-passphrase" class="center">
     <p>Please enter your existing 12-word wallet passphrase and click 'Ok'</p>
     <input type="password" class="btc-wallet-passphrase" id="manualPassphrase" autocomplete="off" >
+    <div id="showhide">
+        <i id="toggle-icon" class="fa fa-2x fa-inverse fa-eye-slash"></i>
+    </div>
  
     <div class="input-group pull-left" style="width:180px" id="amount-value-wrapper">
         <label class="input-group-addon">Format</label>
@@ -62,7 +65,19 @@ $(document).ready(function(){
             dialogMessage('<i class="fa fa-lg fa-fw fa-info-circle"></i> Wallet Updated!', 'Your wallet has been updated to use the passphrase you just entered.', false, false);
         }
     });
-    // }));
+
+    // Allow user to toggle display of passphrase
+    $("#toggle-icon).click(function(){
+        var addOrRemove = $("#manualPassphrase").hasClass('active');
+        if(addOrRemove) {
+            $("#toggle-icon").removeClass('fa-eye').addClass('fa-eye-slash');
+            $("#manualPassphrase").attr("type", "text");
+        } else {
+            $("#toggle-icon").removeClass('fa-eye-slash').addClass('fa-eye');
+            $('#manualPassphrase').attr("type", "password");
+        }
+        $('#manualPassphrase').toggleClass( 'active');
+    });
 
 });
 </script>

--- a/html/passphrase-existing.html
+++ b/html/passphrase-existing.html
@@ -5,7 +5,7 @@
 
     <!--  new markup to show eye of sauron  -->
     <div class="showhide">
-        <i id="toggleIcon" class="fa fa-2x fa-inverse fa-eye-slash" style="bottom:58px; right:20px; position:absolute;"></i>
+        <i id="toggle-icon" class="fa fa-2x fa-inverse fa-eye-slash" style="bottom:58px; right:20px; position:absolute;"></i>
     </div>
  
 
@@ -71,15 +71,15 @@ $(document).ready(function(){
     });
 
     // Allow user to toggle passphrase display
-    $("#toggleIcon").click(function(){
+    $("#toggle-icon").click(function(){
         var addOrRemove = $("#manualPassphrase").hasClass('active');
 
         // set input type to text or password and toggle icon
         if(addOrRemove) {
-            $("#toggleIcon").removeClass('fa-eye').addClass('fa-eye-slash');
+            $("#toggle-icon").removeClass('fa-eye').addClass('fa-eye-slash');
             $("#manualPassphrase").attr("type", "text");
         } else {
-            $("#toggleIcon").removeClass('fa-eye-slash').addClass('fa-eye');
+            $("#toggle-icon").removeClass('fa-eye-slash').addClass('fa-eye');
             $('#manualPassphrase').attr("type", "password");
         }
         $('#manualPassphrase').toggleClass( 'active');

--- a/html/passphrase-existing.html
+++ b/html/passphrase-existing.html
@@ -1,6 +1,6 @@
 <div id="existing-passphrase" class="center">
     <p>Please enter your existing 12-word wallet passphrase and click 'Ok'</p>
-    <input type="text" class="btc-wallet-passphrase" id="manualPassphrase" autocomplete="off" >
+    <input type="password" class="btc-wallet-passphrase" id="manualPassphrase" autocomplete="off" >
  
     <div class="input-group pull-left" style="width:180px" id="amount-value-wrapper">
         <label class="input-group-addon">Format</label>

--- a/html/passphrase-existing.html
+++ b/html/passphrase-existing.html
@@ -2,7 +2,7 @@
     <p>Please enter your existing 12-word wallet passphrase and click 'Ok'</p>
     <input type="text" class="btc-wallet-passphrase" id="manualPassphrase" autocomplete="off" >
     <div class="showhide">
-        <i id="toggle-icon" class="fa fa-2x fa-inverse fa-eye-slash" style="bottom:58px; right:20px; position:absolute;"></i>
+        <i id="toggle-icon" class="fa fa-2x fa-inverse fa-eye-slash"></i>
     </div>
  
     <div class="input-group pull-left" style="width:180px" id="amount-value-wrapper">


### PR DESCRIPTION
fix to deter shoulder surfing by changing passphrase input field type from `text` to `password` 

![passphrase-existing-html](https://user-images.githubusercontent.com/28559/122143724-04383580-ce20-11eb-82a8-59fa0e4aa788.jpg)
