### PR TITLE
Collapsable subassets for a grail card

### DIFF
--- a/css/freewallet-desktop.css
+++ b/css/freewallet-desktop.css
@@ -171,6 +171,9 @@ body:before {
     background-color: #eaeaea;
     border-bottom: 1px solid #e5e5e5;
 }
+.indented {
+    padding-left: 12px;
+}
 .highlight-search-term {
   background-color: yellow;
 }
@@ -370,6 +373,30 @@ body:before {
 }
 .balances-list li > a img {
     margin-right: 1px;
+}
+.balances-list-subasset {
+    background-color: #fff;
+}
+.balances-list-subasset.striped {
+    background-color: #f8f8f8;
+}
+.balances-list-collapsible {
+    display: block;
+    text-align: center;
+    width: 18px;
+    height: 18px;
+    margin-right: 8px;
+    line-height: 14px;
+    font-size: 16px;
+    font-weight: bold;
+    text-decoration: none !important;
+    border-radius: 10px;
+    background-color: #bbb;
+    color: #fff;
+}
+.balances-list-collapsible:hover, .balances-list-collapsible:focus {
+    background-color: #999;
+    color: #fff;
 }
 
 


### PR DESCRIPTION
A better way to list sub-assets that belong to a grail card. Sub-assets that do have a grail will be hidden by default. See the screenshot:

![Screen Shot 2022-04-10 at 4 56 58 PM](https://user-images.githubusercontent.com/3636406/162611747-7ce3fdb5-8ea8-4a0f-94f7-2508c527e825.png)

The reasoning behind this change is to save space in the "balances" list. This became an issue especially with some of the sub-asset heavy projects like PHOCKHEADS. 