### PR TITLE
adjust broadcast transaction failover

### DIFF
--- a/js/freewallet-desktop.js
+++ b/js/freewallet-desktop.js
@@ -3403,18 +3403,18 @@ function broadcastTransaction(network, tx, callback){
                 if(txid)
                     console.log('Broadcasted transaction hash=',txid);
             } else {
-                // If the request to XChain API failed, fallback to chain.so API
+                // If the request to XChain API failed, fallback to blockcypher API
+                var pushtx = {
+                  tx
+                };
                 $.ajax({
                     type: "POST",
-                    url: 'https://chain.so/api/v2/send_tx/' + net,
-                    data: { 
-                        tx_hex: tx 
-                    },
-                    dataType: 'json',
+                    url: 'https://api.blockcypher.com/v1/btc/'+ (network=='testnet') ? 'test3' : 'main' +'/txs/push',
+                    data: JSON.stringify(pushtx),
                     complete: function(o){
                         // console.log('o=',o);
-                        if(o && o.responseJSON && o.responseJSON.data && o.responseJSON.data.txid){
-                            var txid = o.responseJSON.data.txid;
+                        if(o && o.responseJSON && o.responseJSON.data && o.responseJSON.data.tx && o.responseJSON.data.tx.hash){
+                            var txid = o.responseJSON.data.tx.hash;
                             if(callback)
                                 callback(txid);
                             if(txid)


### PR DESCRIPTION
Removed chain.so push_tx endpoint as it seems to be deprecated, this PR introduces blockcypher as a new failover.

Not sure how to build and test locally, so you might want to spin it up and try it as I only tested via REPL/console - should work fine with testnet txs